### PR TITLE
Clarify comment on external object depth display test

### DIFF
--- a/tests/spec/ext_external_objects/vk_depth_display.c
+++ b/tests/spec/ext_external_objects/vk_depth_display.c
@@ -363,8 +363,8 @@ gl_subtest_init(void)
 	glClearColor(0.0, 1.0, 0.0, 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	/* render a blue fullscreen green quad using
-	 * the imported z buffer
+	/* render a blue fullscreen quad using the
+	 * imported z buffer
 	 */
 	glEnable(GL_DEPTH_TEST);
 	glUseProgram(gl_rnd2fbo_prog);


### PR DESCRIPTION
* The test renders a blue fullscreen quad that is partially occluded in the middle because of the depth test with a pre-filled depth buffer.
* Alternatively, we could say "render a blue fullscreen quad with a green quad inside because of the imported z buffer".