### PR TITLE
Deprecated built-in limits from version 150

### DIFF
--- a/tests/spec/glsl-1.50/minimum-maximums.txt
+++ b/tests/spec/glsl-1.50/minimum-maximums.txt
@@ -1,7 +1,6 @@
 150
 gl_MaxVertexAttribs 16
 gl_MaxVertexUniformComponents 1024
-gl_MaxVaryingFloats 60
 gl_MaxVaryingComponents 60
 gl_MaxVertexOutputComponents 64
 gl_MaxGeometryInputComponents 64

--- a/tests/spec/glsl-3.30/minimum-maximums.txt
+++ b/tests/spec/glsl-3.30/minimum-maximums.txt
@@ -1,7 +1,6 @@
 330
 gl_MaxVertexAttribs 16
 gl_MaxVertexUniformComponents 1024
-gl_MaxVaryingFloats 60
 gl_MaxVaryingComponents 60
 gl_MaxVertexOutputComponents 64
 gl_MaxGeometryInputComponents 64


### PR DESCRIPTION
From version 150, according to CORE specification:

"The constant gl_MaxVaryingFloats is deprecated, use gl_MaxVaryingComponents instead."