### PR TITLE
Adjust the judgment logic of AA

### DIFF
--- a/tests/util/piglit-framework-gl/piglit_fbo_framework.c
+++ b/tests/util/piglit-framework-gl/piglit_fbo_framework.c
@@ -144,7 +144,7 @@ piglit_fbo_framework_create(const struct piglit_gl_test_config *test_config)
 
 	platform = piglit_wfl_framework_choose_platform(test_config);
 
-	if (test_config->window_samples > 1) {
+	if (test_config->window_samples < 0) {
 		puts("The FBO mode doesn't support multisampling");
 		piglit_report_result(PIGLIT_SKIP);
 	}


### PR DESCRIPTION
Under the current logic, when the AA multiple is greater than 1, the case will report "The FBO mode does not support multisampling" and will terminate the test. Fix this defect